### PR TITLE
doc: set last version to 0.5

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,12 +45,10 @@ const config = {
             tag: ':::',
             keywords: ['note', 'tip', 'info', 'caution', 'danger', 'issuer', 'verifier', 'holder', 'bob', 'acme'],
           },
-          lastVersion: '0.4',
+          lastVersion: 'current',
           versions: {
             current: {
               label: 'v0.5.x',
-              path: '0.5',
-              banner: 'unreleased',
             },
             0.4: {
               label: 'v0.4.x',


### PR DESCRIPTION
If I understood @genaris correctly, the current version is `0.5`. It's a bit confusing because the current docs uses 0.4 as default.