### PR TITLE
fix(docs): correct tutorial link in guides/getting-started/set-up

### DIFF
--- a/guides/getting-started/set-up/index.md
+++ b/guides/getting-started/set-up/index.md
@@ -192,7 +192,7 @@ Finally, we can initialize the agent and it's ready for use.
 Now that you have your agent setup, it's time to start building your application. Head over to the tutorials page to get started.
 
 <DocCardList items={[
-{ type: 'link', label: 'Tutorials', href: '../tutorials/index', docId: 'tutorials/index' },
+{ type: 'link', label: 'Tutorials', href: '../tutorials', docId: 'tutorials/index' },
 { type: 'link', label: 'Create a Connection', href: '../tutorials/create-a-connection', docId: 'tutorials/create-a-connection' }
 ]} />
 


### PR DESCRIPTION
Fixes a minor typo in the href attribute of the tutorial link in the documentation